### PR TITLE
Update the query for finding all commits belonging to a project

### DIFF
--- a/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/repository/GetCommitsInProjectRepository.java
+++ b/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/repository/GetCommitsInProjectRepository.java
@@ -10,9 +10,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface GetCommitsInProjectRepository extends Neo4jRepository<CommitEntity, Long> {
 
-  @Query(
-      "MATCH (p:ProjectEntity)-[:CONTAINS]->(f:FileEntity)-[:CHANGED_IN]->(c:CommitEntity) WHERE ID(p) = {0} RETURN c "
-          + "UNION MATCH (p:ProjectEntity)-[:CONTAINS]->(m:ModuleEntity)-[:CONTAINS]->(f:FileEntity)-[:CHANGED_IN]->(c:CommitEntity) WHERE ID(p) = {0} RETURN c")
+  @Query("MATCH (p1:ProjectEntity)-[:CONTAINS*]-(f1:FileEntity)-[:CHANGED_IN]->(c1:CommitEntity) " +
+          "OPTIONAL MATCH (c2:CommitEntity)-[:IS_CHILD_OF]->(c1:CommitEntity) " +
+          "WHERE ID(p1) = {0} " +
+          "UNWIND [c1, c2] AS c " +
+          "RETURN DISTINCT c " +
+          "ORDER BY c.timestamp DESC")
   List<CommitEntity> findByProjectId(Long projectId);
 
   @Query(


### PR DESCRIPTION
The new query returns all commits. In the old query, two types of commit were not taken into account:

- Commits in which no files were changed.

- Commits in which only files that were in submodules were changed.

If a project consists only of commits in which no files have been changed, the commits are not collected. However, this happens very rarely and an analysis of such a project makes no sense. Adapting to this situation would involve the domain (a relationship between the project and the first commit would have to be added).