### PR TITLE
Tweak the query to only capture commits associated with the project

### DIFF
--- a/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/repository/GetCommitsInProjectRepository.java
+++ b/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/query/repository/GetCommitsInProjectRepository.java
@@ -10,8 +10,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface GetCommitsInProjectRepository extends Neo4jRepository<CommitEntity, Long> {
 
-  @Query("MATCH (p1:ProjectEntity)-[:CONTAINS*]-(f1:FileEntity)-[:CHANGED_IN]->(c1:CommitEntity) " +
-          "OPTIONAL MATCH (c2:CommitEntity)-[:IS_CHILD_OF]->(c1:CommitEntity) " +
+  @Query("MATCH (p1:ProjectEntity)-[:CONTAINS*]-(f1:FileEntity)-[:CHANGED_IN]->(c1:CommitEntity)<-[:IS_CHILD_OF]-(c2:CommitEntity) " +
           "WHERE ID(p1) = {0} " +
           "UNWIND [c1, c2] AS c " +
           "RETURN DISTINCT c " +


### PR DESCRIPTION
The previous query captured all saved commits because an OPTIONAL MATCH clause is a standalone query. There, the project is ignored.

See also: #4