### PR TITLE
Adapted coderadar-core tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ subprojects {
 
     dependencies {
         testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: version_junit
+        testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: version_mockito_junit
         testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: version_junit
         annotationProcessor("org.projectlombok:lombok:$lombok_version")
         compileOnly("org.projectlombok:lombok:$lombok_version")

--- a/coderadar-core/src/main/java/io/reflectoring/coderadar/projectadministration/service/filepattern/ListFilePatternsOfProjectService.java
+++ b/coderadar-core/src/main/java/io/reflectoring/coderadar/projectadministration/service/filepattern/ListFilePatternsOfProjectService.java
@@ -3,7 +3,6 @@ package io.reflectoring.coderadar.projectadministration.service.filepattern;
 import io.reflectoring.coderadar.projectadministration.ProjectNotFoundException;
 import io.reflectoring.coderadar.projectadministration.domain.FilePattern;
 import io.reflectoring.coderadar.projectadministration.port.driven.filepattern.ListFilePatternsOfProjectPort;
-import io.reflectoring.coderadar.projectadministration.port.driven.project.GetProjectPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.filepattern.get.GetFilePatternResponse;
 import io.reflectoring.coderadar.projectadministration.port.driver.filepattern.get.ListFilePatternsOfProjectUseCase;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,13 +15,11 @@ import java.util.List;
 public class ListFilePatternsOfProjectService implements ListFilePatternsOfProjectUseCase {
 
   private final ListFilePatternsOfProjectPort port;
-  private final GetProjectPort getProjectPort;
 
   @Autowired
   public ListFilePatternsOfProjectService(
-      ListFilePatternsOfProjectPort port, GetProjectPort getProjectPort) {
+      ListFilePatternsOfProjectPort port) {
     this.port = port;
-    this.getProjectPort = getProjectPort;
   }
 
   @Override

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/analyzerconfig/CreateAnalyzerConfigurationServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/analyzerconfig/CreateAnalyzerConfigurationServiceTest.java
@@ -1,41 +1,53 @@
 package io.reflectoring.coderadar.projectadministration.analyzerconfig;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import io.reflectoring.coderadar.projectadministration.domain.AnalyzerConfiguration;
-import io.reflectoring.coderadar.projectadministration.domain.Project;
 import io.reflectoring.coderadar.projectadministration.port.driven.analyzerconfig.CreateAnalyzerConfigurationPort;
-import io.reflectoring.coderadar.projectadministration.port.driven.project.GetProjectPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.analyzerconfig.create.CreateAnalyzerConfigurationCommand;
 import io.reflectoring.coderadar.projectadministration.service.analyzerconfig.CreateAnalyzerConfigurationService;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class CreateAnalyzerConfigurationServiceTest {
-  private CreateAnalyzerConfigurationPort createAnalyzerConfigurationPort =
-      mock(CreateAnalyzerConfigurationPort.class);
-  private GetProjectPort getProjectPort = mock(GetProjectPort.class);
+
+  @Mock private CreateAnalyzerConfigurationPort createConfigurationPortMock;
+
+  private CreateAnalyzerConfigurationService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new CreateAnalyzerConfigurationService(createConfigurationPortMock);
+  }
 
   @Test
   void returnsNewAnalyzerConfigurationId() {
-    CreateAnalyzerConfigurationService testSubject =
-        new CreateAnalyzerConfigurationService(createAnalyzerConfigurationPort);
+    // given
+    long projectId = 1L;
+    String analyzerName = "analyzer";
+    boolean analyzerEnabled = true;
 
     CreateAnalyzerConfigurationCommand command =
-        new CreateAnalyzerConfigurationCommand("analyzer", true);
+        new CreateAnalyzerConfigurationCommand(analyzerName, analyzerEnabled);
 
-    AnalyzerConfiguration analyzerConfiguration = new AnalyzerConfiguration();
-    analyzerConfiguration.setAnalyzerName("analyzer");
-    analyzerConfiguration.setEnabled(true);
+    AnalyzerConfiguration expectedConfiguration = new AnalyzerConfiguration()
+                    .setAnalyzerName(analyzerName)
+                    .setEnabled(analyzerEnabled);
 
-    Mockito.when(createAnalyzerConfigurationPort.create(any(), anyLong())).thenReturn(1L);
-    Mockito.when(getProjectPort.get(1L)).thenReturn(new Project());
+    when(createConfigurationPortMock.create(expectedConfiguration, projectId)).thenReturn(1L);
 
+    // when
     Long analyzerConfigurationId = testSubject.create(command, 1L);
 
-    Assertions.assertEquals(1L, analyzerConfigurationId.longValue());
+    // then
+    assertThat(analyzerConfigurationId).isEqualTo(1L);
+
+    verify(createConfigurationPortMock).create(expectedConfiguration, projectId);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/analyzerconfig/DeleteAnalyzerConfigurationServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/analyzerconfig/DeleteAnalyzerConfigurationServiceTest.java
@@ -1,28 +1,36 @@
 package io.reflectoring.coderadar.projectadministration.analyzerconfig;
 
-import io.reflectoring.coderadar.projectadministration.domain.AnalyzerConfiguration;
+import static org.mockito.Mockito.verify;
+
 import io.reflectoring.coderadar.projectadministration.port.driven.analyzerconfig.DeleteAnalyzerConfigurationPort;
-import io.reflectoring.coderadar.projectadministration.port.driven.analyzerconfig.GetAnalyzerConfigurationPort;
 import io.reflectoring.coderadar.projectadministration.service.analyzerconfig.DeleteAnalyzerConfigurationService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class DeleteAnalyzerConfigurationServiceTest {
-  private DeleteAnalyzerConfigurationPort port = mock(DeleteAnalyzerConfigurationPort.class);
-  private GetAnalyzerConfigurationPort getAnalyzerConfigurationPort =
-      mock(GetAnalyzerConfigurationPort.class);
+
+  @Mock private DeleteAnalyzerConfigurationPort deleteConfigurationPortMock;
+
+  private DeleteAnalyzerConfigurationService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new DeleteAnalyzerConfigurationService(deleteConfigurationPortMock);
+  }
 
   @Test
-  void deleteAnalyzerConfigurationWithIdOne() {
-    DeleteAnalyzerConfigurationService testSubject = new DeleteAnalyzerConfigurationService(port);
+  void deleteAnalyzerConfigurationDeletesConfigurationWithGivenId() {
+    // given
+    long configurationId = 1L;
 
-    Mockito.when(getAnalyzerConfigurationPort.getAnalyzerConfiguration(anyLong()))
-        .thenReturn(new AnalyzerConfiguration());
-    testSubject.deleteAnalyzerConfiguration(1L);
+    // when
+    testSubject.deleteAnalyzerConfiguration(configurationId);
 
-    Mockito.verify(port, Mockito.times(1)).deleteAnalyzerConfiguration(1L);
+    // then
+    verify(deleteConfigurationPortMock).deleteAnalyzerConfiguration(configurationId);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/analyzerconfig/GetAnalyzerConfigurationServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/analyzerconfig/GetAnalyzerConfigurationServiceTest.java
@@ -1,32 +1,52 @@
 package io.reflectoring.coderadar.projectadministration.analyzerconfig;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 import io.reflectoring.coderadar.projectadministration.domain.AnalyzerConfiguration;
 import io.reflectoring.coderadar.projectadministration.port.driven.analyzerconfig.GetAnalyzerConfigurationPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.analyzerconfig.get.GetAnalyzerConfigurationResponse;
 import io.reflectoring.coderadar.projectadministration.service.analyzerconfig.GetAnalyzerConfigurationService;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class GetAnalyzerConfigurationServiceTest {
-  private GetAnalyzerConfigurationPort port = mock(GetAnalyzerConfigurationPort.class);
+
+  @Mock private GetAnalyzerConfigurationPort getConfigurationPortMock;
+
+  private GetAnalyzerConfigurationService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new GetAnalyzerConfigurationService(getConfigurationPortMock);
+  }
 
   @Test
-  void returnsAnalyzerConfigurationWithIdOne() {
-    GetAnalyzerConfigurationService testSubject = new GetAnalyzerConfigurationService(port);
+  void returnsAnalyzerConfigurationWithExpectedId() {
+    // given
+    long configurationId = 1L;
+    String analyzerName = "analyzer";
+    boolean analyzerEnabled = true;
 
-    AnalyzerConfiguration analyzerConfiguration = new AnalyzerConfiguration();
-    analyzerConfiguration.setId(1L);
-    analyzerConfiguration.setAnalyzerName("analyzer");
-    analyzerConfiguration.setEnabled(true);
-    Mockito.when(port.getAnalyzerConfiguration(1L)).thenReturn(analyzerConfiguration);
+    AnalyzerConfiguration analyzerConfiguration = new AnalyzerConfiguration()
+            .setId(configurationId)
+            .setAnalyzerName(analyzerName)
+            .setEnabled(analyzerEnabled);
 
-    GetAnalyzerConfigurationResponse response = testSubject.getSingleAnalyzerConfiguration(1L);
+    GetAnalyzerConfigurationResponse expectedResponse =
+        new GetAnalyzerConfigurationResponse(configurationId, analyzerName, analyzerEnabled);
 
-    Assertions.assertEquals(analyzerConfiguration.getAnalyzerName(), response.getAnalyzerName());
-    Assertions.assertEquals(analyzerConfiguration.getEnabled(), response.getEnabled());
-    Assertions.assertEquals(analyzerConfiguration.getId(), response.getId());
+    when(getConfigurationPortMock.getAnalyzerConfiguration(1L)).thenReturn(analyzerConfiguration);
+
+    // when
+    GetAnalyzerConfigurationResponse actualResponse =
+        testSubject.getSingleAnalyzerConfiguration(1L);
+
+    // then
+    assertThat(actualResponse).isEqualTo(expectedResponse);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/analyzerconfig/ListAnalyzerConfigurationsFromProjectServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/analyzerconfig/ListAnalyzerConfigurationsFromProjectServiceTest.java
@@ -1,57 +1,61 @@
 package io.reflectoring.coderadar.projectadministration.analyzerconfig;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 import io.reflectoring.coderadar.projectadministration.domain.AnalyzerConfiguration;
-import io.reflectoring.coderadar.projectadministration.domain.Project;
 import io.reflectoring.coderadar.projectadministration.port.driven.analyzerconfig.GetAnalyzerConfigurationsFromProjectPort;
-import io.reflectoring.coderadar.projectadministration.port.driven.project.GetProjectPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.analyzerconfig.get.GetAnalyzerConfigurationResponse;
 import io.reflectoring.coderadar.projectadministration.service.analyzerconfig.ListAnalyzerConfigurationsFromProjectService;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class ListAnalyzerConfigurationsFromProjectServiceTest {
-  private GetAnalyzerConfigurationsFromProjectPort port =
-      mock(GetAnalyzerConfigurationsFromProjectPort.class);
-  private GetProjectPort getProjectPort = mock(GetProjectPort.class);
+
+  @Mock private GetAnalyzerConfigurationsFromProjectPort getConfigurationsPortMock;
+
+  private ListAnalyzerConfigurationsFromProjectService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new ListAnalyzerConfigurationsFromProjectService(getConfigurationsPortMock);
+  }
 
   @Test
   void returnsTwoAnalyzerConfigurationsFromProject() {
-    ListAnalyzerConfigurationsFromProjectService testSubject =
-        new ListAnalyzerConfigurationsFromProjectService(port);
+    // given
+    long projectId = 1L;
 
-    Mockito.when(getProjectPort.get(anyLong())).thenReturn(new Project());
+    AnalyzerConfiguration analyzerConfiguration1 = new AnalyzerConfiguration()
+            .setId(1L)
+            .setAnalyzerName("analyzer 1")
+            .setEnabled(true);
+    AnalyzerConfiguration analyzerConfiguration2 = new AnalyzerConfiguration()
+            .setId(2L)
+            .setAnalyzerName("analyzer 2")
+            .setEnabled(false);
 
-    AnalyzerConfiguration analyzerConfiguration1 = new AnalyzerConfiguration();
-    analyzerConfiguration1.setId(1L);
-    analyzerConfiguration1.setAnalyzerName("analyzer 1");
-    analyzerConfiguration1.setEnabled(true);
-    AnalyzerConfiguration analyzerConfiguration2 = new AnalyzerConfiguration();
-    analyzerConfiguration2.setId(2L);
-    analyzerConfiguration2.setAnalyzerName("analyzer 2");
-    analyzerConfiguration2.setEnabled(false);
     List<AnalyzerConfiguration> configurations = new ArrayList<>();
     configurations.add(analyzerConfiguration1);
     configurations.add(analyzerConfiguration2);
 
-    Mockito.when(port.get(1L)).thenReturn(configurations);
+    GetAnalyzerConfigurationResponse expectedResponse1 =
+        new GetAnalyzerConfigurationResponse(1L, "analyzer 1", true);
+    GetAnalyzerConfigurationResponse expectedResponse2 =
+        new GetAnalyzerConfigurationResponse(2L, "analyzer 2", false);
 
-    List<GetAnalyzerConfigurationResponse> response = testSubject.get(1L);
+    when(getConfigurationsPortMock.get(projectId)).thenReturn(configurations);
 
-    Assertions.assertEquals(configurations.size(), response.size());
-    Assertions.assertEquals(analyzerConfiguration1.getId(), response.get(0).getId());
-    Assertions.assertEquals(analyzerConfiguration2.getId(), response.get(1).getId());
-    Assertions.assertEquals(
-        analyzerConfiguration1.getAnalyzerName(), response.get(0).getAnalyzerName());
-    Assertions.assertEquals(
-        analyzerConfiguration2.getAnalyzerName(), response.get(1).getAnalyzerName());
-    Assertions.assertEquals(analyzerConfiguration1.getEnabled(), response.get(0).getEnabled());
-    Assertions.assertEquals(analyzerConfiguration2.getEnabled(), response.get(1).getEnabled());
+    // given
+    List<GetAnalyzerConfigurationResponse> actualResponse = testSubject.get(projectId);
+
+    // then
+    assertThat(actualResponse).containsExactly(expectedResponse1, expectedResponse2);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/analyzerconfig/UpdateAnalyzerConfigurationServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/analyzerconfig/UpdateAnalyzerConfigurationServiceTest.java
@@ -1,40 +1,54 @@
 package io.reflectoring.coderadar.projectadministration.analyzerconfig;
 
+import static org.mockito.Mockito.*;
+
 import io.reflectoring.coderadar.projectadministration.domain.AnalyzerConfiguration;
 import io.reflectoring.coderadar.projectadministration.port.driven.analyzerconfig.GetAnalyzerConfigurationPort;
 import io.reflectoring.coderadar.projectadministration.port.driven.analyzerconfig.UpdateAnalyzerConfigurationPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.analyzerconfig.update.UpdateAnalyzerConfigurationCommand;
 import io.reflectoring.coderadar.projectadministration.service.analyzerconfig.UpdateAnalyzerConfigurationService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class UpdateAnalyzerConfigurationServiceTest {
-  private UpdateAnalyzerConfigurationPort updateAnalyzerConfigurationPort =
-      mock(UpdateAnalyzerConfigurationPort.class);
-  private GetAnalyzerConfigurationPort getAnalyzerConfigurationPort =
-      mock(GetAnalyzerConfigurationPort.class);
+
+  @Mock private UpdateAnalyzerConfigurationPort updateConfigurationPortMock;
+
+  @Mock private GetAnalyzerConfigurationPort getConfigurationPortMock;
+
+  private UpdateAnalyzerConfigurationService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject =
+        new UpdateAnalyzerConfigurationService(
+                updateConfigurationPortMock, getConfigurationPortMock);
+  }
 
   @Test
-  void updateAnalyzerConfigurationWithIdOne() {
-    UpdateAnalyzerConfigurationService testSubject =
-        new UpdateAnalyzerConfigurationService(
-            updateAnalyzerConfigurationPort, getAnalyzerConfigurationPort);
+  void updateAnalyzerConfigurationUpdatesNameAndEnabled(@Mock AnalyzerConfiguration existingConfigurationMock) {
+    // given
+    long configurationId = 1L;
+    String newConfigurationName = "new analyzer name";
 
     UpdateAnalyzerConfigurationCommand command =
-        new UpdateAnalyzerConfigurationCommand("new analyzer name", true);
+        new UpdateAnalyzerConfigurationCommand(newConfigurationName, false);
 
-    AnalyzerConfiguration analyzerConfiguration = new AnalyzerConfiguration();
-    analyzerConfiguration.setId(1L);
-    analyzerConfiguration.setAnalyzerName("new analyzer name");
-    analyzerConfiguration.setEnabled(true);
+    when(getConfigurationPortMock.getAnalyzerConfiguration(configurationId))
+        .thenReturn(existingConfigurationMock);
 
-    Mockito.when(getAnalyzerConfigurationPort.getAnalyzerConfiguration(1L))
-        .thenReturn(analyzerConfiguration);
-
+    // when
     testSubject.update(command, 1L);
 
-    Mockito.verify(updateAnalyzerConfigurationPort, Mockito.times(1)).update(analyzerConfiguration);
+    // then
+    verify(existingConfigurationMock, never()).setId(any());
+    verify(existingConfigurationMock).setAnalyzerName(newConfigurationName);
+    verify(existingConfigurationMock).setEnabled(false);
+
+    verify(updateConfigurationPortMock).update(existingConfigurationMock);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/filepattern/CreateFilePatternServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/filepattern/CreateFilePatternServiceTest.java
@@ -8,34 +8,49 @@ import io.reflectoring.coderadar.projectadministration.port.driven.project.GetPr
 import io.reflectoring.coderadar.projectadministration.port.driver.filepattern.create.CreateFilePatternCommand;
 import io.reflectoring.coderadar.projectadministration.service.filepattern.CreateFilePatternService;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class CreateFilePatternServiceTest {
-  private GetProjectPort getProjectPort = mock(GetProjectPort.class);
-  private CreateFilePatternPort createFilePatternPort = mock(CreateFilePatternPort.class);
+
+  @Mock private CreateFilePatternPort createFilePatternPort;
+
+  private CreateFilePatternService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new CreateFilePatternService(createFilePatternPort);
+  }
 
   @Test
   void returnsNewFilePatternId() {
-    CreateFilePatternService testSubject = new CreateFilePatternService(createFilePatternPort);
+    // given
+    long projectId = 1L;
+    long expectedFilePatternId = 1337L;
+    String pattern = "**/*.java";
+    InclusionType inclusionType = InclusionType.INCLUDE;
 
-    Project project = new Project();
-    project.setId(1L);
-    project.setName("project name");
-
-    Mockito.when(getProjectPort.get(1L)).thenReturn(project);
-
-    FilePattern filePattern = new FilePattern();
-    filePattern.setPattern("**/*.java");
-    filePattern.setInclusionType(InclusionType.INCLUDE);
-    Mockito.when(createFilePatternPort.createFilePattern(filePattern, 1L)).thenReturn(1L);
+    FilePattern filePattern = new FilePattern()
+            .setPattern(pattern)
+            .setInclusionType(inclusionType);
 
     CreateFilePatternCommand command =
-        new CreateFilePatternCommand("**/*.java", InclusionType.INCLUDE);
-    Long filePatternId = testSubject.createFilePattern(command, project.getId());
+            new CreateFilePatternCommand(pattern, inclusionType);
 
-    Assertions.assertEquals(1L, filePatternId.longValue());
+    when(createFilePatternPort.createFilePattern(filePattern, projectId)).thenReturn(expectedFilePatternId);
+
+    // when
+    Long filePatternId = testSubject.createFilePattern(command, projectId);
+
+    // then
+    assertThat(filePatternId).isEqualTo(expectedFilePatternId);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/filepattern/DeleteFilePatternServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/filepattern/DeleteFilePatternServiceTest.java
@@ -1,26 +1,36 @@
 package io.reflectoring.coderadar.projectadministration.filepattern;
 
-import io.reflectoring.coderadar.projectadministration.domain.FilePattern;
+import static org.mockito.Mockito.verify;
+
 import io.reflectoring.coderadar.projectadministration.port.driven.filepattern.DeleteFilePatternPort;
-import io.reflectoring.coderadar.projectadministration.port.driven.filepattern.GetFilePatternPort;
 import io.reflectoring.coderadar.projectadministration.service.filepattern.DeleteFilePatternService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class DeleteFilePatternServiceTest {
-  private DeleteFilePatternPort port = mock(DeleteFilePatternPort.class);
-  private GetFilePatternPort getFilePatternPort = mock(GetFilePatternPort.class);
+
+  @Mock private DeleteFilePatternPort port;
+
+  private DeleteFilePatternService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new DeleteFilePatternService(port);
+  }
 
   @Test
-  void deleteFilePatternWithIdOne() {
-    DeleteFilePatternService testSubject = new DeleteFilePatternService(port);
+  void deleteFilePatternDeletesPatternWithGivenId() {
+    // given
+    long patternId = 1L;
 
-    Mockito.when(getFilePatternPort.get(anyLong())).thenReturn(new FilePattern());
-    testSubject.delete(1L);
+    // when
+    testSubject.delete(patternId);
 
-    Mockito.verify(port, Mockito.times(1)).delete(1L);
+    // then
+    verify(port).delete(1L);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/filepattern/GetFilePatternServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/filepattern/GetFilePatternServiceTest.java
@@ -5,30 +5,48 @@ import io.reflectoring.coderadar.projectadministration.domain.InclusionType;
 import io.reflectoring.coderadar.projectadministration.port.driven.filepattern.GetFilePatternPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.filepattern.get.GetFilePatternResponse;
 import io.reflectoring.coderadar.projectadministration.service.filepattern.GetFilePatternService;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class GetFilePatternServiceTest {
-  private GetFilePatternPort port = mock(GetFilePatternPort.class);
+
+  @Mock private GetFilePatternPort port;
+
+  private GetFilePatternService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new GetFilePatternService(port);
+  }
 
   @Test
   void returnsGetFilePatternResponseForFilePattern() {
-    GetFilePatternService testSubject = new GetFilePatternService(port);
+    // given
+    long patternId = 123L;
+    String pattern = "**/*.java";
+    InclusionType inclusionType = InclusionType.EXCLUDE;
 
-    FilePattern filePattern = new FilePattern();
-    filePattern.setId(1L);
-    filePattern.setPattern("**/*.java");
-    filePattern.setInclusionType(InclusionType.INCLUDE);
+    FilePattern filePattern = new FilePattern()
+            .setId(patternId)
+            .setPattern(pattern)
+            .setInclusionType(inclusionType);
 
-    Mockito.when(port.get(1L)).thenReturn(filePattern);
+    GetFilePatternResponse expectedResponse =
+            new GetFilePatternResponse(patternId, pattern, inclusionType);
 
-    GetFilePatternResponse response = testSubject.get(1L);
+    when(port.get(patternId)).thenReturn(filePattern);
 
-    Assertions.assertEquals(filePattern.getId(), response.getId());
-    Assertions.assertEquals(filePattern.getPattern(), response.getPattern());
-    Assertions.assertEquals(filePattern.getInclusionType(), response.getInclusionType());
+    // when
+    GetFilePatternResponse actualResponse = testSubject.get(patternId);
+
+    // then
+    assertThat(actualResponse).isEqualTo(expectedResponse);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/filepattern/ListFilePatternsOfProjectServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/filepattern/ListFilePatternsOfProjectServiceTest.java
@@ -1,55 +1,62 @@
 package io.reflectoring.coderadar.projectadministration.filepattern;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 import io.reflectoring.coderadar.projectadministration.domain.FilePattern;
 import io.reflectoring.coderadar.projectadministration.domain.InclusionType;
-import io.reflectoring.coderadar.projectadministration.domain.Project;
 import io.reflectoring.coderadar.projectadministration.port.driven.filepattern.ListFilePatternsOfProjectPort;
-import io.reflectoring.coderadar.projectadministration.port.driven.project.GetProjectPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.filepattern.get.GetFilePatternResponse;
 import io.reflectoring.coderadar.projectadministration.service.filepattern.ListFilePatternsOfProjectService;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class ListFilePatternsOfProjectServiceTest {
-  private ListFilePatternsOfProjectPort port = mock(ListFilePatternsOfProjectPort.class);
-  private GetProjectPort getProjectPort = mock(GetProjectPort.class);
+
+  @Mock private ListFilePatternsOfProjectPort listPatternsPortMock;
+
+  private ListFilePatternsOfProjectService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new ListFilePatternsOfProjectService(listPatternsPortMock);
+  }
 
   @Test
   void returnsTwoFilePatternsFromProject() {
-    ListFilePatternsOfProjectService testSubject =
-        new ListFilePatternsOfProjectService(port, getProjectPort);
+    // given
+    long projectId = 123L;
 
-    Mockito.when(getProjectPort.get(anyLong())).thenReturn(new Project());
+    FilePattern filePattern1 = new FilePattern()
+            .setId(1L)
+            .setPattern("**/*.java")
+            .setInclusionType(InclusionType.INCLUDE);
+    FilePattern filePattern2 = new FilePattern()
+            .setId(2L)
+            .setPattern("**/*.xml")
+            .setInclusionType(InclusionType.EXCLUDE);
 
     List<FilePattern> filePatterns = new ArrayList<>();
-    FilePattern filePattern1 = new FilePattern();
-    filePattern1.setId(1L);
-    filePattern1.setPattern("**/*.java");
-    filePattern1.setInclusionType(InclusionType.INCLUDE);
-    FilePattern filePattern2 = new FilePattern();
-    filePattern2.setId(2L);
-    filePattern2.setPattern("**/*.xml");
-    filePattern2.setInclusionType(InclusionType.EXCLUDE);
     filePatterns.add(filePattern1);
     filePatterns.add(filePattern2);
 
-    Mockito.when(port.listFilePatterns(1L)).thenReturn(filePatterns);
+    GetFilePatternResponse expectedResponse1 =
+            new GetFilePatternResponse(1L, "**/*.java", InclusionType.INCLUDE);
+    GetFilePatternResponse expectedResponse2 =
+            new GetFilePatternResponse(2L, "**/*.xml", InclusionType.EXCLUDE);
 
-    List<GetFilePatternResponse> response = testSubject.listFilePatterns(1L);
+    when(listPatternsPortMock.listFilePatterns(projectId)).thenReturn(filePatterns);
 
-    Assertions.assertEquals(filePatterns.size(), response.size());
-    Assertions.assertEquals(filePattern1.getId(), response.get(0).getId());
-    Assertions.assertEquals(filePattern1.getPattern(), response.get(0).getPattern());
-    Assertions.assertEquals(filePattern1.getInclusionType(), response.get(0).getInclusionType());
-    Assertions.assertEquals(filePattern2.getId(), response.get(1).getId());
-    Assertions.assertEquals(filePattern2.getPattern(), response.get(1).getPattern());
-    Assertions.assertEquals(filePattern2.getInclusionType(), response.get(1).getInclusionType());
+    // when
+    List<GetFilePatternResponse> actualResponse = testSubject.listFilePatterns(projectId);
+
+    // then
+    assertThat(actualResponse).containsExactly(expectedResponse1, expectedResponse2);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/filepattern/UpdateFilePatternServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/filepattern/UpdateFilePatternServiceTest.java
@@ -6,31 +6,49 @@ import io.reflectoring.coderadar.projectadministration.port.driven.filepattern.G
 import io.reflectoring.coderadar.projectadministration.port.driven.filepattern.UpdateFilePatternPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.filepattern.update.UpdateFilePatternCommand;
 import io.reflectoring.coderadar.projectadministration.service.filepattern.UpdateFilePatternService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class UpdateFilePatternServiceTest {
-  private GetFilePatternPort getFilePatternPort = mock(GetFilePatternPort.class);
-  private UpdateFilePatternPort updateFilePatternPort = mock(UpdateFilePatternPort.class);
+
+  @Mock private GetFilePatternPort getFilePatternPortMock;
+
+  @Mock private UpdateFilePatternPort updateFilePatternPortMock;
+
+  private UpdateFilePatternService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new UpdateFilePatternService(getFilePatternPortMock, updateFilePatternPortMock);
+  }
 
   @Test
-  void updateFilePatternWithIdOne() {
-    UpdateFilePatternService testSubject =
-        new UpdateFilePatternService(getFilePatternPort, updateFilePatternPort);
-
-    FilePattern filePattern = new FilePattern();
-    filePattern.setId(1L);
-    filePattern.setPattern("**/*.java");
-    filePattern.setInclusionType(InclusionType.INCLUDE);
-
-    Mockito.when(getFilePatternPort.get(1L)).thenReturn(filePattern);
+  void updateFilePatternUpdatesPatternAndInclusionType(@Mock FilePattern existingFilePatternMock) {
+    // given
+    long patternId = 1L;
+    String newPattern = "**/*.java";
+    InclusionType newInclusionType = InclusionType.EXCLUDE;
 
     UpdateFilePatternCommand command =
-        new UpdateFilePatternCommand("**/*.java", InclusionType.INCLUDE);
-    testSubject.updateFilePattern(command, filePattern.getId());
+            new UpdateFilePatternCommand(newPattern, newInclusionType);
 
-    Mockito.verify(updateFilePatternPort, Mockito.times(1)).updateFilePattern(filePattern);
+    when(getFilePatternPortMock.get(patternId)).thenReturn(existingFilePatternMock);
+
+    // when
+    testSubject.updateFilePattern(command, patternId);
+
+    // then
+    verify(existingFilePatternMock, never()).setId(anyLong());
+    verify(existingFilePatternMock).setPattern(newPattern);
+    verify(existingFilePatternMock).setInclusionType(newInclusionType);
+
+    verify(updateFilePatternPortMock).updateFilePattern(existingFilePatternMock);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/module/CreateModuleServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/module/CreateModuleServiceTest.java
@@ -22,8 +22,7 @@ import org.mockito.stubbing.Answer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class CreateModuleServiceTest {
@@ -53,11 +52,13 @@ class CreateModuleServiceTest {
     CreateModuleCommand command = new CreateModuleCommand("module-path");
 
     when(saveModulePortMock.saveModule(expectedModule, projectId)).thenReturn(expectedModuleId);
-    when(processProjectServiceMock.executeTask(any(), anyLong())).thenAnswer((Answer<Void>) invocation -> {
+
+    doAnswer((Answer<Void>) invocation -> {
       Runnable runnable = invocation.getArgument(0);
       runnable.run();
+
       return null;
-    });
+    }).when(processProjectServiceMock).executeTask(any(), eq(projectId));
 
     // when
     Long actualModuleId = testSubject.createModule(command, projectId);

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/module/CreateModuleServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/module/CreateModuleServiceTest.java
@@ -1,7 +1,5 @@
 package io.reflectoring.coderadar.projectadministration.module;
 
-import static org.mockito.Mockito.mock;
-
 import io.reflectoring.coderadar.projectadministration.ModuleAlreadyExistsException;
 import io.reflectoring.coderadar.projectadministration.ModulePathInvalidException;
 import io.reflectoring.coderadar.projectadministration.ProjectIsBeingProcessedException;
@@ -14,35 +12,59 @@ import io.reflectoring.coderadar.projectadministration.port.driver.module.create
 import io.reflectoring.coderadar.projectadministration.service.ProcessProjectService;
 import io.reflectoring.coderadar.projectadministration.service.module.CreateModuleService;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 class CreateModuleServiceTest {
-  private CreateModulePort createModulePort = mock(CreateModulePort.class);
-  private GetProjectPort getProjectPort = mock(GetProjectPort.class);
-  private ProcessProjectService processProjectService = mock(ProcessProjectService.class);
-  private SaveModulePort saveModulePort = mock(SaveModulePort.class);
+
+  @Mock private CreateModulePort createModulePortMock;
+
+  @Mock private SaveModulePort saveModulePortMock;
+
+  @Mock private ProcessProjectService processProjectServiceMock;
+
+  private CreateModuleService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new CreateModuleService(createModulePortMock, saveModulePortMock, processProjectServiceMock);
+  }
 
   @Test
-  void returnsNewModuleId()
-      throws ModulePathInvalidException, ModuleAlreadyExistsException,
-          ProjectIsBeingProcessedException {
-    CreateModuleService testSubject =
-        new CreateModuleService(createModulePort, saveModulePort, processProjectService);
+  void returnsNewModuleId() throws ModulePathInvalidException, ModuleAlreadyExistsException, ProjectIsBeingProcessedException {
+    // given
+    long projectId = 1L;
+    long expectedModuleId = 123L;
 
-    Project project = new Project();
-    project.setId(2L);
-    project.setName("project name");
-
-    Mockito.when(getProjectPort.get(2L)).thenReturn(project);
-
-    Module module = new Module();
-    module.setPath("module-path");
-    Mockito.when(saveModulePort.saveModule(module, 2L)).thenReturn(1L);
+    Module expectedModule = new Module()
+            .setPath("module-path");
 
     CreateModuleCommand command = new CreateModuleCommand("module-path");
-    Long moduleId = testSubject.createModule(command, project.getId());
 
-    Assertions.assertEquals(1L, moduleId.longValue());
+    when(saveModulePortMock.saveModule(expectedModule, projectId)).thenReturn(expectedModuleId);
+    when(processProjectServiceMock.executeTask(any(), anyLong())).thenAnswer((Answer<Void>) invocation -> {
+      Runnable runnable = invocation.getArgument(0);
+      runnable.run();
+      return null;
+    });
+
+    // when
+    Long actualModuleId = testSubject.createModule(command, projectId);
+
+    // then
+    assertThat(actualModuleId).isEqualTo(expectedModuleId);
+
+    verify(createModulePortMock).createModule(expectedModuleId, projectId);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/module/DeleteModuleServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/module/DeleteModuleServiceTest.java
@@ -2,8 +2,8 @@ package io.reflectoring.coderadar.projectadministration.module;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 import io.reflectoring.coderadar.projectadministration.ProjectIsBeingProcessedException;
 import io.reflectoring.coderadar.projectadministration.domain.Module;
@@ -40,12 +40,12 @@ class DeleteModuleServiceTest {
     long moduleId = 1L;
     long projectId = 2L;
 
-    when(processProjectServiceMock.executeTask(any(), anyLong())).thenAnswer((Answer<Void>) invocation -> {
+    doAnswer((Answer<Void>) invocation -> {
       Runnable runnable = invocation.getArgument(0);
       runnable.run();
 
       return null;
-    });
+    }).when(processProjectServiceMock).executeTask(any(), eq(projectId));
 
     // when
     testSubject.delete(moduleId, projectId);

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/module/DeleteModuleServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/module/DeleteModuleServiceTest.java
@@ -1,7 +1,9 @@
 package io.reflectoring.coderadar.projectadministration.module;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.reflectoring.coderadar.projectadministration.ProjectIsBeingProcessedException;
 import io.reflectoring.coderadar.projectadministration.domain.Module;
@@ -9,22 +11,46 @@ import io.reflectoring.coderadar.projectadministration.port.driven.module.Delete
 import io.reflectoring.coderadar.projectadministration.port.driven.module.GetModulePort;
 import io.reflectoring.coderadar.projectadministration.service.ProcessProjectService;
 import io.reflectoring.coderadar.projectadministration.service.module.DeleteModuleService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
+@ExtendWith(MockitoExtension.class)
 class DeleteModuleServiceTest {
-  private DeleteModulePort deleteModulePort = mock(DeleteModulePort.class);
-  private GetModulePort getModulePort = mock(GetModulePort.class);
-  private ProcessProjectService processProjectService = mock(ProcessProjectService.class);
+
+  @Mock private DeleteModulePort deleteModulePortMock;
+
+  @Mock private ProcessProjectService processProjectServiceMock;
+
+  @Mock private GetModulePort getModulePortMock;
+
+  private DeleteModuleService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new DeleteModuleService(deleteModulePortMock, processProjectServiceMock, getModulePortMock);
+  }
 
   @Test
-  void deleteModuleWithIdOne() throws ProjectIsBeingProcessedException {
-    DeleteModuleService testSubject =
-        new DeleteModuleService(deleteModulePort, processProjectService, getModulePort);
+  void deleteModuleDeletesModuleWithGivenId() throws ProjectIsBeingProcessedException {
+    // given
+    long moduleId = 1L;
+    long projectId = 2L;
 
-    Mockito.when(getModulePort.get(anyLong())).thenReturn(new Module());
-    testSubject.delete(1L, 2L);
+    when(processProjectServiceMock.executeTask(any(), anyLong())).thenAnswer((Answer<Void>) invocation -> {
+      Runnable runnable = invocation.getArgument(0);
+      runnable.run();
 
-    // Mockito.verify(deleteModulePort, Mockito.times(1)).delete(1L, 2L);
+      return null;
+    });
+
+    // when
+    testSubject.delete(moduleId, projectId);
+
+    // then
+    verify(deleteModulePortMock).delete(moduleId, projectId);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/module/GetModuleServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/module/GetModuleServiceTest.java
@@ -5,26 +5,46 @@ import io.reflectoring.coderadar.projectadministration.port.driven.module.GetMod
 import io.reflectoring.coderadar.projectadministration.port.driver.module.get.GetModuleResponse;
 import io.reflectoring.coderadar.projectadministration.service.module.GetModuleService;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class GetModuleServiceTest {
-  private GetModulePort getModulePort = mock(GetModulePort.class);
+
+  @Mock private GetModulePort getModulePortMock;
+
+  private GetModuleService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new GetModuleService(getModulePortMock);
+  }
 
   @Test
   void returnsGetModuleResponseForModule() {
-    GetModuleService testSubject = new GetModuleService(getModulePort);
+    // given
+    long moduleId = 1L;
+    String path = "module-path";
 
-    Module module = new Module();
-    module.setId(1L);
-    module.setPath("module-path");
-    Mockito.when(getModulePort.get(1L)).thenReturn(module);
+    Module module = new Module()
+            .setId(moduleId)
+            .setPath(path);
 
-    GetModuleResponse response = testSubject.get(1L);
+    GetModuleResponse expectedResponse = new GetModuleResponse(moduleId, path);
 
-    Assertions.assertEquals(module.getId(), response.getId());
-    Assertions.assertEquals(module.getPath(), response.getPath());
+    when(getModulePortMock.get(moduleId)).thenReturn(module);
+
+    // when
+    GetModuleResponse actualResponse = testSubject.get(moduleId);
+
+    // then
+    assertThat(actualResponse).isEqualTo(expectedResponse);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/module/ListModulesOfProjectServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/module/ListModulesOfProjectServiceTest.java
@@ -1,53 +1,61 @@
 package io.reflectoring.coderadar.projectadministration.module;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
 import io.reflectoring.coderadar.projectadministration.domain.Module;
 import io.reflectoring.coderadar.projectadministration.domain.Project;
 import io.reflectoring.coderadar.projectadministration.port.driven.module.ListModulesOfProjectPort;
-import io.reflectoring.coderadar.projectadministration.port.driven.project.GetProjectPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.module.get.GetModuleResponse;
 import io.reflectoring.coderadar.projectadministration.service.module.ListModulesOfProjectService;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class ListModulesOfProjectServiceTest {
-  private ListModulesOfProjectPort port = mock(ListModulesOfProjectPort.class);
-  private GetProjectPort getProjectPort = mock(GetProjectPort.class);
+
+  @Mock private ListModulesOfProjectPort listModulesPortMock;
+
+  private ListModulesOfProjectService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new ListModulesOfProjectService(listModulesPortMock);
+  }
 
   @Test
   void returnsTwoModulesFromProject() {
-    ListModulesOfProjectService testSubject = new ListModulesOfProjectService(port);
+    // given
+    long projectId = 1234L;
 
-    Mockito.when(getProjectPort.get(anyLong())).thenReturn(new Project());
-
-    Project project = new Project();
-    project.setId(1L);
+    Module module1 = new Module()
+            .setId(1L)
+            .setPath("module-path-one");
+    Module module2 = new Module()
+            .setId(2L)
+            .setPath("module-path-two");
 
     List<Module> modules = new ArrayList<>();
-    Module module1 = new Module();
-    module1.setId(1L);
-    module1.setPath("module-path-one");
-    Module module2 = new Module();
-    module2.setId(2L);
-    module2.setPath("module-path-two");
-
     modules.add(module1);
     modules.add(module2);
 
-    Mockito.when(port.listModules(project.getId())).thenReturn(modules);
+    GetModuleResponse expectedResponse1 = new GetModuleResponse(1L, "module-path-one");
+    GetModuleResponse expectedResponse2 = new GetModuleResponse(2L, "module-path-two");
 
-    List<GetModuleResponse> response = testSubject.listModules(project.getId());
+    when(listModulesPortMock.listModules(projectId)).thenReturn(modules);
 
-    Assertions.assertEquals(modules.size(), response.size());
-    Assertions.assertEquals(module1.getId(), response.get(0).getId());
-    Assertions.assertEquals(module1.getPath(), response.get(0).getPath());
-    Assertions.assertEquals(module2.getId(), response.get(1).getId());
-    Assertions.assertEquals(module2.getPath(), response.get(1).getPath());
+    // when
+    List<GetModuleResponse> actualResponses = testSubject.listModules(projectId);
+
+    // then
+    assertThat(actualResponses).containsExactly(expectedResponse1, expectedResponse2);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/CreateProjectServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/CreateProjectServiceTest.java
@@ -4,8 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import io.reflectoring.coderadar.CoderadarConfigurationProperties;
 import io.reflectoring.coderadar.analyzer.domain.Commit;
@@ -121,12 +120,12 @@ class CreateProjectServiceTest {
       return expectedProjectId;
     });
 
-    when(processProjectService.executeTask(any(), anyLong())).thenAnswer((Answer<Void>) invocation -> {
+    doAnswer((Answer<Void>) invocation -> {
       Runnable runnable = invocation.getArgument(0);
       runnable.run();
 
       return null;
-    });
+    }).when(processProjectService).executeTask(any(), eq(expectedProjectId));
 
     when(coderadarConfigurationProperties.getWorkdir())
             .thenReturn(new File(globalWorkdirName).toPath());

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/DeleteProjectServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/DeleteProjectServiceTest.java
@@ -1,37 +1,51 @@
 package io.reflectoring.coderadar.projectadministration.project;
 
-import static org.mockito.ArgumentMatchers.anyLong;
-
 import io.reflectoring.coderadar.projectadministration.ProjectIsBeingProcessedException;
-import io.reflectoring.coderadar.projectadministration.domain.Project;
 import io.reflectoring.coderadar.projectadministration.port.driven.project.DeleteProjectPort;
-import io.reflectoring.coderadar.projectadministration.port.driven.project.GetProjectPort;
 import io.reflectoring.coderadar.projectadministration.service.ProcessProjectService;
 import io.reflectoring.coderadar.projectadministration.service.project.DeleteProjectService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DeleteProjectServiceTest {
 
-  @Mock private DeleteProjectPort deleteProjectPort;
+  @Mock private DeleteProjectPort deleteProjectPortMock;
 
-  @Mock private GetProjectPort getProjectPort;
+  @Mock private ProcessProjectService processProjectServiceMock;
 
-  @Mock private ProcessProjectService processProjectService;
+  private DeleteProjectService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new DeleteProjectService(deleteProjectPortMock, processProjectServiceMock);
+  }
 
   @Test
   void deleteProjectWithIdOne() throws ProjectIsBeingProcessedException {
-    DeleteProjectService testSubject =
-        new DeleteProjectService(deleteProjectPort, processProjectService);
+    // given
+    long projectId = 1L;
 
-    Mockito.when(getProjectPort.get(anyLong())).thenReturn(new Project());
+    when(processProjectServiceMock.executeTask(any(), anyLong())).thenAnswer((Answer<Void>) invocation -> {
+      Runnable runnable = invocation.getArgument(0);
+      runnable.run();
 
-    testSubject.delete(1L);
+      return null;
+    });
 
-    // Mockito.verify(deleteProjectPort, Mockito.times(1)).delete(1L);
+    // when
+    testSubject.delete(projectId);
+
+    // then
+    verify(deleteProjectPortMock).delete(projectId);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/DeleteProjectServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/DeleteProjectServiceTest.java
@@ -1,7 +1,6 @@
 package io.reflectoring.coderadar.projectadministration.project;
 
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
 
 import io.reflectoring.coderadar.projectadministration.ProjectIsBeingProcessedException;
 import io.reflectoring.coderadar.projectadministration.domain.Project;
@@ -10,12 +9,19 @@ import io.reflectoring.coderadar.projectadministration.port.driven.project.GetPr
 import io.reflectoring.coderadar.projectadministration.service.ProcessProjectService;
 import io.reflectoring.coderadar.projectadministration.service.project.DeleteProjectService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class DeleteProjectServiceTest {
-  private DeleteProjectPort deleteProjectPort = mock(DeleteProjectPort.class);
-  private GetProjectPort getProjectPort = mock(GetProjectPort.class);
-  private ProcessProjectService processProjectService = mock(ProcessProjectService.class);
+
+  @Mock private DeleteProjectPort deleteProjectPort;
+
+  @Mock private GetProjectPort getProjectPort;
+
+  @Mock private ProcessProjectService processProjectService;
 
   @Test
   void deleteProjectWithIdOne() throws ProjectIsBeingProcessedException {

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/DeleteProjectServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/DeleteProjectServiceTest.java
@@ -13,8 +13,7 @@ import org.mockito.stubbing.Answer;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class DeleteProjectServiceTest {
@@ -35,12 +34,12 @@ class DeleteProjectServiceTest {
     // given
     long projectId = 1L;
 
-    when(processProjectServiceMock.executeTask(any(), anyLong())).thenAnswer((Answer<Void>) invocation -> {
+    doAnswer((Answer<Void>) invocation -> {
       Runnable runnable = invocation.getArgument(0);
       runnable.run();
 
       return null;
-    });
+    }).when(processProjectServiceMock).executeTask(any(), anyLong());
 
     // when
     testSubject.delete(projectId);

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/GetProjectServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/GetProjectServiceTest.java
@@ -5,41 +5,66 @@ import io.reflectoring.coderadar.projectadministration.port.driven.project.GetPr
 import io.reflectoring.coderadar.projectadministration.port.driver.project.get.GetProjectResponse;
 import io.reflectoring.coderadar.projectadministration.service.project.GetProjectService;
 import java.util.Date;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class GetProjectServiceTest {
 
-  @Mock private GetProjectPort getProjectPort;
+  @Mock private GetProjectPort getProjectPortMock;
+
+  private GetProjectService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new GetProjectService(getProjectPortMock);
+  }
 
   @Test
   void returnsGetProjectResponseWithIdOne() {
-    GetProjectService testSubject = new GetProjectService(getProjectPort);
+    // given
+    long projectId = 1L;
+    String projectName = "project name";
+    String workdirName = "workdir-name";
+    String vcsUrl = "http://valid.url";
+    String vcsUsername = "username";
+    String vcsPassword = "password";
+    Date startDate = new Date();
+    Date endDate = new Date();
 
-    Project project = new Project();
-    project.setId(1L);
-    project.setName("project name");
-    project.setWorkdirName("workdir name");
-    project.setVcsUrl("http://valid.url");
-    project.setVcsUsername("username");
-    project.setVcsPassword("password");
-    project.setVcsOnline(true);
-    project.setVcsStart(new Date());
-    project.setVcsEnd(new Date());
+    Project project = new Project()
+            .setId(projectId)
+            .setName(projectName)
+            .setWorkdirName(workdirName)
+            .setVcsUrl(vcsUrl)
+            .setVcsUsername(vcsUsername)
+            .setVcsPassword(vcsPassword)
+            .setVcsOnline(true)
+            .setVcsStart(startDate)
+            .setVcsEnd(endDate);
 
-    Mockito.when(getProjectPort.get(1L)).thenReturn(project);
+    GetProjectResponse expectedResponse = new GetProjectResponse()
+            .setId(projectId)
+            .setName(projectName)
+            .setVcsUrl(vcsUrl)
+            .setVcsUsername(vcsUsername)
+            .setVcsPassword(vcsPassword)
+            .setVcsOnline(true)
+            .setStart(startDate)
+            .setEnd(endDate);
 
-    GetProjectResponse response = testSubject.get(1L);
+    when(getProjectPortMock.get(projectId)).thenReturn(project);
 
-    Assertions.assertEquals(project.getId(), response.getId());
-    Assertions.assertEquals(project.getName(), response.getName());
-    Assertions.assertEquals(project.isVcsOnline(), response.getVcsOnline());
-    Assertions.assertEquals(project.getVcsUsername(), response.getVcsUsername());
-    Assertions.assertEquals(project.getVcsPassword(), response.getVcsPassword());
+    // when
+    GetProjectResponse actualResponse = testSubject.get(1L);
+
+    // then
+    assertThat(actualResponse).isEqualTo(expectedResponse);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/GetProjectServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/GetProjectServiceTest.java
@@ -4,17 +4,18 @@ import io.reflectoring.coderadar.projectadministration.domain.Project;
 import io.reflectoring.coderadar.projectadministration.port.driven.project.GetProjectPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.project.get.GetProjectResponse;
 import io.reflectoring.coderadar.projectadministration.service.project.GetProjectService;
+import java.util.Date;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Date;
-
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class GetProjectServiceTest {
 
-  private GetProjectPort getProjectPort = mock(GetProjectPort.class);
+  @Mock private GetProjectPort getProjectPort;
 
   @Test
   void returnsGetProjectResponseWithIdOne() {

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/ListProjectsServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/ListProjectsServiceTest.java
@@ -7,56 +7,83 @@ import io.reflectoring.coderadar.projectadministration.service.project.ListProje
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @ExtendWith(MockitoExtension.class)
 class ListProjectsServiceTest {
 
   @Mock
-  private ListProjectsPort port;
+  private ListProjectsPort listProjectsPort;
+
+  private ListProjectsService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new ListProjectsService(listProjectsPort);
+  }
 
   @Test
   void returnsTwoProjects() {
-    ListProjectsService testSubject = new ListProjectsService(port);
+    // given
+    Date startDate = new Date();
+    Date endDate = new Date();
 
-    Project project1 = new Project();
-    project1.setId(1L);
-    project1.setName("project 1");
-    project1.setVcsUsername("username1");
-    project1.setVcsPassword("password1");
-    project1.setVcsOnline(true);
-    project1.setVcsStart(new Date());
-    project1.setVcsEnd(new Date());
+    Project project1 = new Project()
+            .setId(1L)
+            .setName("project 1")
+            .setVcsUrl("http://github.com")
+            .setVcsUsername("username1")
+            .setVcsPassword("password1")
+            .setVcsOnline(true)
+            .setVcsStart(startDate)
+            .setVcsEnd(endDate);
 
-    Project project2 = new Project();
-    project2.setId(2L);
-    project2.setName("project 2");
-    project2.setVcsUsername("username2");
-    project2.setVcsPassword("password2");
-    project2.setVcsOnline(true);
-    project2.setVcsStart(new Date());
-    project2.setVcsEnd(new Date());
+    Project project2 = new Project()
+            .setId(2L)
+            .setName("project 2")
+            .setVcsUrl("http://bitbucket.org")
+            .setVcsUsername("username2")
+            .setVcsPassword("password2")
+            .setVcsOnline(false)
+            .setVcsStart(startDate)
+            .setVcsEnd(endDate);
+
     List<Project> projects = new ArrayList<>();
     projects.add(project1);
     projects.add(project2);
 
-    Mockito.when(port.getProjects()).thenReturn(projects);
+    GetProjectResponse expectedResponse1 = new GetProjectResponse()
+            .setId(1L)
+            .setName("project 1")
+            .setVcsUrl("http://github.com")
+            .setVcsUsername("username1")
+            .setVcsPassword("password1")
+            .setVcsOnline(true)
+            .setStart(startDate)
+            .setEnd(endDate);
+    GetProjectResponse expectedResponse2 = new GetProjectResponse()
+            .setId(2L)
+            .setName("project 2")
+            .setVcsUrl("http://bitbucket.org")
+            .setVcsUsername("username2")
+            .setVcsPassword("password2")
+            .setVcsOnline(false)
+            .setStart(startDate)
+            .setEnd(endDate);
 
-    List<GetProjectResponse> response = testSubject.listProjects();
+    Mockito.when(listProjectsPort.getProjects()).thenReturn(projects);
 
-    Assertions.assertEquals(projects.size(), response.size());
-    Assertions.assertEquals(project1.getId(), response.get(0).getId());
-    Assertions.assertEquals(project1.getName(), response.get(0).getName());
-    Assertions.assertEquals(project1.getVcsUsername(), response.get(0).getVcsUsername());
-    Assertions.assertEquals(project1.getVcsPassword(), response.get(0).getVcsPassword());
-    Assertions.assertEquals(project2.getId(), response.get(1).getId());
-    Assertions.assertEquals(project2.getName(), response.get(1).getName());
-    Assertions.assertEquals(project2.getVcsUsername(), response.get(1).getVcsUsername());
-    Assertions.assertEquals(project2.getVcsPassword(), response.get(1).getVcsPassword());
+    // when
+    List<GetProjectResponse> actualResponses = testSubject.listProjects();
+
+    // then
+    assertThat(actualResponses).containsExactly(expectedResponse1, expectedResponse2);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/ListProjectsServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/ListProjectsServiceTest.java
@@ -4,18 +4,21 @@ import io.reflectoring.coderadar.projectadministration.domain.Project;
 import io.reflectoring.coderadar.projectadministration.port.driven.project.ListProjectsPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.project.get.GetProjectResponse;
 import io.reflectoring.coderadar.projectadministration.service.project.ListProjectsService;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class ListProjectsServiceTest {
-  private ListProjectsPort port = mock(ListProjectsPort.class);
+
+  @Mock
+  private ListProjectsPort port;
 
   @Test
   void returnsTwoProjects() {

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/UpdateProjectServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/UpdateProjectServiceTest.java
@@ -1,7 +1,5 @@
 package io.reflectoring.coderadar.projectadministration.project;
 
-import static org.mockito.Mockito.mock;
-
 import io.reflectoring.coderadar.CoderadarConfigurationProperties;
 import io.reflectoring.coderadar.projectadministration.ProjectAlreadyExistsException;
 import io.reflectoring.coderadar.projectadministration.domain.Project;
@@ -18,20 +16,32 @@ import java.util.Collections;
 import java.util.Date;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.TaskScheduler;
 
+@ExtendWith(MockitoExtension.class)
 class UpdateProjectServiceTest {
-  private GetProjectPort getProjectPort = mock(GetProjectPort.class);
-  private UpdateProjectPort updateProjectPort = mock(UpdateProjectPort.class);
-  private UpdateRepositoryUseCase updateRepositoryUseCase = mock(UpdateRepositoryUseCase.class);
-  private CoderadarConfigurationProperties coderadarConfigurationProperties =
-      mock(CoderadarConfigurationProperties.class);
-  private ProcessProjectService processProjectService = mock(ProcessProjectService.class);
-  private UpdateCommitsPort updateCommitsPort = mock(UpdateCommitsPort.class);
-  private GetProjectCommitsUseCase getProjectCommitsUseCase = mock(GetProjectCommitsUseCase.class);
-  private ProjectStatusPort projectStatusPort = mock(ProjectStatusPort.class);
-  private TaskScheduler taskScheduler = mock(TaskScheduler.class);
+
+  @Mock private GetProjectPort getProjectPort;
+
+  @Mock private UpdateProjectPort updateProjectPort;
+
+  @Mock private UpdateRepositoryUseCase updateRepositoryUseCase;
+
+  @Mock private CoderadarConfigurationProperties coderadarConfigurationProperties;
+
+  @Mock private ProcessProjectService processProjectService;
+
+  @Mock private GetProjectCommitsUseCase getProjectCommitsUseCase;
+
+  @Mock private UpdateCommitsPort updateCommitsPort;
+
+  @Mock private ProjectStatusPort projectStatusPort;
+
+  @Mock private TaskScheduler taskScheduler;
 
   @Test
   void updateProjectReturnsErrorWhenProjectWithNameAlreadyExists() {

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/UpdateProjectServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/UpdateProjectServiceTest.java
@@ -48,15 +48,15 @@ class UpdateProjectServiceTest {
 
   @Mock private CoderadarConfigurationProperties configurationPropertiesMock;
 
-  @Mock private ProcessProjectService processProjectService;
+  @Mock private ProcessProjectService processProjectServiceMock;
 
-  @Mock private GetProjectCommitsUseCase getProjectCommitsUseCase;
+  @Mock private GetProjectCommitsUseCase getProjectCommitsUseCaseMock;
 
-  @Mock private UpdateCommitsPort updateCommitsPort;
+  @Mock private UpdateCommitsPort updateCommitsPortMock;
 
-  @Mock private ProjectStatusPort projectStatusPort;
+  @Mock private ProjectStatusPort projectStatusPortMock;
 
-  @Mock private TaskScheduler taskScheduler;
+  @Mock private TaskScheduler taskSchedulerMock;
 
   private UpdateProjectService testSubject;
 
@@ -67,11 +67,11 @@ class UpdateProjectServiceTest {
             updateProjectPortMock,
             updateRepositoryUseCaseMock,
             configurationPropertiesMock,
-            processProjectService,
-            getProjectCommitsUseCase,
-            updateCommitsPort,
-            projectStatusPort,
-            taskScheduler);
+            processProjectServiceMock,
+            getProjectCommitsUseCaseMock,
+            updateCommitsPortMock,
+            projectStatusPortMock,
+            taskSchedulerMock);
   }
 
   @Test
@@ -147,16 +147,16 @@ class UpdateProjectServiceTest {
     when(getProjectPortMock.findByName(newProjectName))
             .thenReturn(Collections.emptyList());
 
-    when(processProjectService.executeTask(any(), eq(projectId))).thenAnswer((Answer<Void>) invocation -> {
+    doAnswer((Answer<Void>) invocation -> {
       Runnable runnable = invocation.getArgument(0);
       runnable.run();
 
       return null;
-    });
+    }).when(processProjectServiceMock).executeTask(any(), eq(projectId));
 
     when(configurationPropertiesMock.getWorkdir()).thenReturn(new File(globalWorkdirName).toPath());
 
-    when(getProjectCommitsUseCase.getCommits(Paths.get(projectWorkdirName), expectedDateRange))
+    when(getProjectCommitsUseCaseMock.getCommits(Paths.get(projectWorkdirName), expectedDateRange))
             .thenReturn(Collections.singletonList(commitMock));
 
     // when
@@ -173,6 +173,6 @@ class UpdateProjectServiceTest {
     verify(projectToUpdateMock).setVcsOnline(false);
 
     verify(updateRepositoryUseCaseMock).updateRepository(expectedUpdatedRepositoryPath);
-    verify(updateCommitsPort).updateCommits(Collections.singletonList(commitMock), projectId);
+    verify(updateCommitsPortMock).updateCommits(Collections.singletonList(commitMock), projectId);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/UpdateProjectServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/project/UpdateProjectServiceTest.java
@@ -1,7 +1,9 @@
 package io.reflectoring.coderadar.projectadministration.project;
 
 import io.reflectoring.coderadar.CoderadarConfigurationProperties;
+import io.reflectoring.coderadar.analyzer.domain.Commit;
 import io.reflectoring.coderadar.projectadministration.ProjectAlreadyExistsException;
+import io.reflectoring.coderadar.projectadministration.ProjectIsBeingProcessedException;
 import io.reflectoring.coderadar.projectadministration.domain.Project;
 import io.reflectoring.coderadar.projectadministration.port.driven.analyzer.UpdateCommitsPort;
 import io.reflectoring.coderadar.projectadministration.port.driven.project.GetProjectPort;
@@ -10,28 +12,41 @@ import io.reflectoring.coderadar.projectadministration.port.driven.project.Updat
 import io.reflectoring.coderadar.projectadministration.port.driver.project.update.UpdateProjectCommand;
 import io.reflectoring.coderadar.projectadministration.service.ProcessProjectService;
 import io.reflectoring.coderadar.projectadministration.service.project.UpdateProjectService;
+import io.reflectoring.coderadar.query.domain.DateRange;
+import io.reflectoring.coderadar.vcs.UnableToUpdateRepositoryException;
 import io.reflectoring.coderadar.vcs.port.driver.GetProjectCommitsUseCase;
 import io.reflectoring.coderadar.vcs.port.driver.UpdateRepositoryUseCase;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
-import org.junit.jupiter.api.Assertions;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import org.springframework.scheduling.TaskScheduler;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UpdateProjectServiceTest {
 
-  @Mock private GetProjectPort getProjectPort;
+  @Mock private GetProjectPort getProjectPortMock;
 
-  @Mock private UpdateProjectPort updateProjectPort;
+  @Mock private UpdateProjectPort updateProjectPortMock;
 
-  @Mock private UpdateRepositoryUseCase updateRepositoryUseCase;
+  @Mock private UpdateRepositoryUseCase updateRepositoryUseCaseMock;
 
-  @Mock private CoderadarConfigurationProperties coderadarConfigurationProperties;
+  @Mock private CoderadarConfigurationProperties configurationPropertiesMock;
 
   @Mock private ProcessProjectService processProjectService;
 
@@ -43,42 +58,121 @@ class UpdateProjectServiceTest {
 
   @Mock private TaskScheduler taskScheduler;
 
-  @Test
-  void updateProjectReturnsErrorWhenProjectWithNameAlreadyExists() {
-    UpdateProjectService testSubject =
-        new UpdateProjectService(
-            getProjectPort,
-            updateProjectPort,
-            updateRepositoryUseCase,
-            coderadarConfigurationProperties,
+  private UpdateProjectService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new UpdateProjectService(
+            getProjectPortMock,
+            updateProjectPortMock,
+            updateRepositoryUseCaseMock,
+            configurationPropertiesMock,
             processProjectService,
             getProjectCommitsUseCase,
             updateCommitsPort,
             projectStatusPort,
             taskScheduler);
+  }
+
+  @Test
+  void updateProjectReturnsErrorWhenProjectWithNameAlreadyExists(@Mock Project projectToUpdateMock) {
+    // given
+    long projectId = 123L;
+    String newProjectName = "new name";
+    String newUsername = "newUsername";
+    String newPassword = "newPassword";
+    Date newStartDate = new Date();
+    Date newEndDate = new Date();
 
     UpdateProjectCommand command =
         new UpdateProjectCommand(
-            "new project name",
-            "username",
-            "password",
+            newProjectName,
+            newUsername,
+            newPassword,
             "http://valid.url",
             true,
-            new Date(),
-            new Date());
+            newStartDate,
+            newEndDate);
 
-    Project project = new Project();
-    project.setId(1L);
-    project.setName("new project name");
+    Project projectWithCollidingName = new Project()
+            .setId(1L)
+            .setName(newProjectName);
 
-    Project project2 = new Project();
-    project2.setId(2L);
-    project2.setName("new project name");
+    when(getProjectPortMock.get(projectId)).thenReturn(projectToUpdateMock);
 
-    Mockito.when(getProjectPort.findByName(project.getName()))
-        .thenReturn(Collections.singletonList(project2));
+    when(getProjectPortMock.findByName(newProjectName))
+        .thenReturn(Collections.singletonList(projectWithCollidingName));
 
-    Assertions.assertThrows(
-        ProjectAlreadyExistsException.class, () -> testSubject.update(command, 1L));
+    // when / then
+    assertThatThrownBy(() -> testSubject.update(command, projectId))
+            .isInstanceOf(ProjectAlreadyExistsException.class);
+  }
+
+  @Test
+  void updateProjectSuccessfullyUpdatesProjectIfNameIsUnique(@Mock Project projectToUpdateMock, @Mock Commit commitMock) throws ProjectIsBeingProcessedException, UnableToUpdateRepositoryException {
+    // given
+    long projectId = 123L;
+    String newProjectName = "new name";
+    String newUsername = "newUsername";
+    String newPassword = "newPassword";
+    String newVcsUrl = "http://new.valid.url";
+    Date newStartDate = new Date();
+    Date newEndDate = new Date();
+    String projectWorkdirName = "project-workdir";
+    String globalWorkdirName = "coderadar-workdir";
+
+    DateRange expectedDateRange = new DateRange(
+            newStartDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
+            newEndDate.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
+    );
+
+    UpdateProjectCommand command =
+            new UpdateProjectCommand(
+                    newProjectName,
+                    newUsername,
+                    newPassword,
+                    newVcsUrl,
+                    false,
+                    newStartDate,
+                    newEndDate);
+
+    Path expectedUpdatedRepositoryPath =
+            new File(globalWorkdirName + "/projects/" + projectWorkdirName).toPath();
+
+    when(getProjectPortMock.get(projectId)).thenReturn(projectToUpdateMock);
+    when(projectToUpdateMock.getWorkdirName()).thenReturn(projectWorkdirName);
+    when(projectToUpdateMock.getVcsStart()).thenReturn(newStartDate);
+    when(projectToUpdateMock.getVcsEnd()).thenReturn(newEndDate);
+
+    when(getProjectPortMock.findByName(newProjectName))
+            .thenReturn(Collections.emptyList());
+
+    when(processProjectService.executeTask(any(), eq(projectId))).thenAnswer((Answer<Void>) invocation -> {
+      Runnable runnable = invocation.getArgument(0);
+      runnable.run();
+
+      return null;
+    });
+
+    when(configurationPropertiesMock.getWorkdir()).thenReturn(new File(globalWorkdirName).toPath());
+
+    when(getProjectCommitsUseCase.getCommits(Paths.get(projectWorkdirName), expectedDateRange))
+            .thenReturn(Collections.singletonList(commitMock));
+
+    // when
+    testSubject.update(command, projectId);
+
+    // then
+    verify(projectToUpdateMock, never()).setId(anyLong());
+    verify(projectToUpdateMock).setName(newProjectName);
+    verify(projectToUpdateMock).setVcsUrl(newVcsUrl);
+    verify(projectToUpdateMock).setVcsUsername(newUsername);
+    verify(projectToUpdateMock).setVcsPassword(newPassword);
+    verify(projectToUpdateMock).setVcsStart(newStartDate);
+    verify(projectToUpdateMock).setVcsEnd(newEndDate);
+    verify(projectToUpdateMock).setVcsOnline(false);
+
+    verify(updateRepositoryUseCaseMock).updateRepository(expectedUpdatedRepositoryPath);
+    verify(updateCommitsPort).updateCommits(Collections.singletonList(commitMock), projectId);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/ChangePasswordServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/ChangePasswordServiceTest.java
@@ -1,7 +1,6 @@
 package io.reflectoring.coderadar.projectadministration.user;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 import io.reflectoring.coderadar.projectadministration.domain.User;
 import io.reflectoring.coderadar.projectadministration.port.driven.user.ChangePasswordPort;
@@ -9,31 +8,44 @@ import io.reflectoring.coderadar.projectadministration.port.driven.user.RefreshT
 import io.reflectoring.coderadar.projectadministration.port.driver.user.password.ChangePasswordCommand;
 import io.reflectoring.coderadar.projectadministration.service.user.password.ChangePasswordService;
 import io.reflectoring.coderadar.projectadministration.service.user.refresh.RefreshTokenService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ChangePasswordServiceTest {
 
-  @Mock private ChangePasswordPort changePasswordPort;
+  @Mock private ChangePasswordPort changePasswordPortMock;
 
-  @Mock private RefreshTokenService refreshTokenService;
+  @Mock private RefreshTokenService refreshTokenServiceMock;
 
-  @Mock private RefreshTokenPort refreshTokenPort;
+  @Mock private RefreshTokenPort refreshTokenPortMock;
+
+  private ChangePasswordService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new ChangePasswordService(refreshTokenPortMock, refreshTokenServiceMock, changePasswordPortMock);
+  }
 
   @Test
-  void changePasswordSuccessfully() {
-    ChangePasswordService testSubject =
-        new ChangePasswordService(refreshTokenPort, refreshTokenService, changePasswordPort);
+  void changePasswordSuccessfully(@Mock User userToUpdateMock) {
+    // given
+    String refreshToken = "refresh-token";
+    String newPassword = "new-password";
 
-    Mockito.when(refreshTokenService.getUser(anyString())).thenReturn(new User());
+    ChangePasswordCommand command = new ChangePasswordCommand(refreshToken, newPassword);
 
-    ChangePasswordCommand command = new ChangePasswordCommand("refresh token", "new password");
+    when(refreshTokenServiceMock.getUser(refreshToken)).thenReturn(userToUpdateMock);
+
+    // when
     testSubject.changePassword(command);
 
-    Mockito.verify(changePasswordPort, Mockito.times(1)).changePassword(any());
+    // then
+    verify(userToUpdateMock).setPassword(anyString());
+    verify(changePasswordPortMock).changePassword(userToUpdateMock);
+    verify(refreshTokenPortMock).deleteByUser(userToUpdateMock);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/ChangePasswordServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/ChangePasswordServiceTest.java
@@ -1,24 +1,28 @@
 package io.reflectoring.coderadar.projectadministration.user;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+
 import io.reflectoring.coderadar.projectadministration.domain.User;
 import io.reflectoring.coderadar.projectadministration.port.driven.user.ChangePasswordPort;
 import io.reflectoring.coderadar.projectadministration.port.driven.user.RefreshTokenPort;
-import io.reflectoring.coderadar.projectadministration.port.driven.user.RegisterUserPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.user.password.ChangePasswordCommand;
 import io.reflectoring.coderadar.projectadministration.service.user.password.ChangePasswordService;
 import io.reflectoring.coderadar.projectadministration.service.user.refresh.RefreshTokenService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class ChangePasswordServiceTest {
-  private ChangePasswordPort changePasswordPort = mock(ChangePasswordPort.class);
-  private RefreshTokenService refreshTokenService = mock(RefreshTokenService.class);
-  private RegisterUserPort registerUserPort = mock(RegisterUserPort.class);
-  private RefreshTokenPort refreshTokenPort = mock(RefreshTokenPort.class);
+
+  @Mock private ChangePasswordPort changePasswordPort;
+
+  @Mock private RefreshTokenService refreshTokenService;
+
+  @Mock private RefreshTokenPort refreshTokenPort;
 
   @Test
   void changePasswordSuccessfully() {

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/LoadUserServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/LoadUserServiceTest.java
@@ -4,30 +4,44 @@ import io.reflectoring.coderadar.projectadministration.domain.User;
 import io.reflectoring.coderadar.projectadministration.port.driven.user.LoadUserPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.user.load.LoadUserResponse;
 import io.reflectoring.coderadar.projectadministration.service.user.load.LoadUserService;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class LoadUserServiceTest {
 
-  @Mock private LoadUserPort loadUserPort;
+  @Mock private LoadUserPort loadUserPortMock;
+
+  private LoadUserService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new LoadUserService(loadUserPortMock);
+  }
 
   @Test
   void loadUserWithIdOne() {
-    LoadUserService testSubject = new LoadUserService(loadUserPort);
+    // given
+    long userId = 1L;
+    String username = "username";
+    User user = new User()
+            .setId(userId)
+            .setUsername(username);
 
-    User user = new User();
-    user.setId(1L);
-    user.setUsername("username");
+    LoadUserResponse expectedResponse = new LoadUserResponse(userId, username);
 
-    Mockito.when(loadUserPort.loadUser(user.getId())).thenReturn(user);
+    when(loadUserPortMock.loadUser(userId)).thenReturn(user);
 
-    LoadUserResponse response = testSubject.loadUser(1L);
+    // when
+    LoadUserResponse actualResponse = testSubject.loadUser(userId);
 
-    Assertions.assertEquals(user.getUsername(), response.getUsername());
+    // then
+    assertThat(actualResponse).isEqualTo(expectedResponse);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/LoadUserServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/LoadUserServiceTest.java
@@ -6,12 +6,15 @@ import io.reflectoring.coderadar.projectadministration.port.driver.user.load.Loa
 import io.reflectoring.coderadar.projectadministration.service.user.load.LoadUserService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class LoadUserServiceTest {
-  private LoadUserPort loadUserPort = mock(LoadUserPort.class);
+
+  @Mock private LoadUserPort loadUserPort;
 
   @Test
   void loadUserWithIdOne() {

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/LoginUserServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/LoginUserServiceTest.java
@@ -9,16 +9,22 @@ import io.reflectoring.coderadar.projectadministration.service.user.login.LoginU
 import io.reflectoring.coderadar.projectadministration.service.user.security.TokenService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.AuthenticationManager;
 
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class LoginUserServiceTest {
-  private RefreshTokenPort refreshTokenPort = mock(RefreshTokenPort.class);
-  private LoadUserPort loadUserPort = mock(LoadUserPort.class);
-  private TokenService tokenService = mock(TokenService.class);
-  private AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
+
+  @Mock private RefreshTokenPort refreshTokenPort;
+
+  @Mock private LoadUserPort loadUserPort;
+
+  @Mock private TokenService tokenService;
+
+  @Mock private AuthenticationManager authenticationManager;
 
   @Test
   void loginUserWithUsernameAndPassword() {

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/LoginUserServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/LoginUserServiceTest.java
@@ -1,5 +1,6 @@
 package io.reflectoring.coderadar.projectadministration.user;
 
+import io.reflectoring.coderadar.projectadministration.domain.RefreshToken;
 import io.reflectoring.coderadar.projectadministration.domain.User;
 import io.reflectoring.coderadar.projectadministration.port.driven.user.LoadUserPort;
 import io.reflectoring.coderadar.projectadministration.port.driven.user.RefreshTokenPort;
@@ -7,45 +8,71 @@ import io.reflectoring.coderadar.projectadministration.port.driver.user.login.Lo
 import io.reflectoring.coderadar.projectadministration.port.driver.user.login.LoginUserResponse;
 import io.reflectoring.coderadar.projectadministration.service.user.login.LoginUserService;
 import io.reflectoring.coderadar.projectadministration.service.user.security.TokenService;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class LoginUserServiceTest {
 
-  @Mock private RefreshTokenPort refreshTokenPort;
+  @Mock private LoadUserPort loadUserPortMock;
 
-  @Mock private LoadUserPort loadUserPort;
+  @Mock private RefreshTokenPort refreshTokenPortMock;
 
-  @Mock private TokenService tokenService;
+  @Mock private AuthenticationManager authenticationManagerMock;
 
-  @Mock private AuthenticationManager authenticationManager;
+  @Mock private TokenService tokenServiceMock;
+
+  private LoginUserService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject =
+            new LoginUserService(loadUserPortMock, refreshTokenPortMock, authenticationManagerMock, tokenServiceMock);
+  }
 
   @Test
   void loginUserWithUsernameAndPassword() {
-    LoginUserService testSubject =
-        new LoginUserService(loadUserPort, refreshTokenPort, authenticationManager, tokenService);
+    // when
+    long userId = 1L;
+    String username = "username";
+    String password = "password";
+    String expectedAccessToken = "abalfgubhfuo[oi3y0823pdyu";
+    String expectedRefreshToken = "ift021789f21897f2187fg";
+    User user = new User()
+            .setId(userId)
+            .setUsername(username);
 
-    User user = new User();
-    user.setId(1L);
-    user.setUsername("username");
+    UsernamePasswordAuthenticationToken expectedToken =
+            new UsernamePasswordAuthenticationToken(username, password);
+    LoginUserResponse expectedResponse = new LoginUserResponse(expectedAccessToken, expectedRefreshToken);
+    RefreshToken expectedRefreshTokenEntity = new RefreshToken()
+            .setToken(expectedRefreshToken)
+            .setUser(user);
 
-    Mockito.when(tokenService.generateAccessToken(user.getId(), user.getUsername()))
-        .thenReturn("abalfgubhfuo[oi3y0823pdyu");
-    Mockito.when(tokenService.generateRefreshToken(user.getId(), user.getUsername()))
-        .thenReturn("ift021789f21897f2187fg");
+    LoginUserCommand command = new LoginUserCommand(username, password);
 
-    Mockito.when(loadUserPort.loadUserByUsername(user.getUsername())).thenReturn(user);
+    when(loadUserPortMock.loadUserByUsername(user.getUsername())).thenReturn(user);
 
-    LoginUserCommand command = new LoginUserCommand("username", "password");
-    LoginUserResponse response = testSubject.login(command);
+    when(tokenServiceMock.generateAccessToken(userId, username))
+        .thenReturn(expectedAccessToken);
+    when(tokenServiceMock.generateRefreshToken(userId, username))
+        .thenReturn(expectedRefreshToken);
 
-    Assertions.assertEquals("abalfgubhfuo[oi3y0823pdyu", response.getAccessToken());
-    Assertions.assertEquals("ift021789f21897f2187fg", response.getRefreshToken());
+    // when
+    LoginUserResponse actualResponse = testSubject.login(command);
+
+    // then
+    assertThat(actualResponse).isEqualTo(expectedResponse);
+
+    verify(authenticationManagerMock).authenticate(expectedToken);
+    verify(refreshTokenPortMock).saveToken(expectedRefreshTokenEntity);
   }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/RefreshTokenServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/RefreshTokenServiceTest.java
@@ -32,7 +32,7 @@ class RefreshTokenServiceTest {
   private RefreshTokenService testSubject;
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     testSubject = new RefreshTokenService(loadUserPort, refreshTokenPort, tokenService);
   }
 

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/RefreshTokenServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/RefreshTokenServiceTest.java
@@ -1,13 +1,24 @@
 package io.reflectoring.coderadar.projectadministration.user;
 
+import io.reflectoring.coderadar.projectadministration.AccessTokenNotExpiredException;
+import io.reflectoring.coderadar.projectadministration.RefreshTokenNotFoundException;
+import io.reflectoring.coderadar.projectadministration.UserNotFoundException;
+import io.reflectoring.coderadar.projectadministration.domain.RefreshToken;
+import io.reflectoring.coderadar.projectadministration.domain.User;
 import io.reflectoring.coderadar.projectadministration.port.driven.user.LoadUserPort;
 import io.reflectoring.coderadar.projectadministration.port.driven.user.RefreshTokenPort;
+import io.reflectoring.coderadar.projectadministration.port.driver.user.refresh.RefreshTokenCommand;
 import io.reflectoring.coderadar.projectadministration.service.user.refresh.RefreshTokenService;
 import io.reflectoring.coderadar.projectadministration.service.user.security.TokenService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class RefreshTokenServiceTest {
@@ -25,18 +36,188 @@ class RefreshTokenServiceTest {
     testSubject = new RefreshTokenService(loadUserPort, refreshTokenPort, tokenService);
   }
 
-  // TODO: Service tests
-  /*  @Test
-  void returnsNewAccessToken() {
-    when(tokenService.isExpired(anyString())).thenReturn(true);
-    when(refreshTokenPort.findByToken(anyString())).thenReturn(new RefreshToken());
+  @Test
+  void refreshTokenRefreshesTokenWhenAccessTokenIsExpired() {
+    // given
+    String refreshToken = "refresh-token";
+    String accessToken = "access-token";
+    RefreshToken refreshTokenEntity = new RefreshToken();
+    long userId = 1L;
+    String username = "username";
+    String expectedAccessToken = "expected-access-token";
 
-    String refreshToken = "refreshToken";
-    String newAccessToken = "newAccessToken";
+    User user = new User()
+            .setId(userId)
+            .setUsername(username);
 
-    RefreshTokenCommand refreshTokenCommand = new RefreshTokenCommand("AAAA", refreshToken);
-    String responseToken = testSubject.refreshToken(refreshTokenCommand);
+    RefreshTokenCommand refreshTokenCommand = new RefreshTokenCommand(accessToken, refreshToken);
 
-    Assertions.assertEquals(newAccessToken, responseToken);
-  }*/
+    when(tokenService.isExpired(accessToken)).thenReturn(true);
+    when(refreshTokenPort.findByToken(refreshToken)).thenReturn(refreshTokenEntity);
+    when(tokenService.getUsername(refreshToken)).thenReturn(username);
+    when(loadUserPort.loadUserByUsername(username)).thenReturn(user);
+    when(tokenService.generateAccessToken(userId, username)).thenReturn(expectedAccessToken);
+
+    // when
+    String actualAccessToken = testSubject.refreshToken(refreshTokenCommand);
+
+    // then
+    assertThat(actualAccessToken).isEqualTo(expectedAccessToken);
+
+    verify(refreshTokenPort).updateRefreshToken(refreshToken, expectedAccessToken);
+  }
+
+  @Test
+  void refreshTokenThrowsExceptionWhenAccessTokenNotExpired() {
+    // given
+    String refreshToken = "refresh-token";
+    String accessToken = "access-token";
+
+    RefreshTokenCommand refreshTokenCommand = new RefreshTokenCommand(accessToken, refreshToken);
+
+    when(tokenService.isExpired(accessToken)).thenReturn(false);
+
+    // when / then
+    assertThatThrownBy(() -> testSubject.refreshToken(refreshTokenCommand))
+            .isInstanceOf(AccessTokenNotExpiredException.class);
+  }
+
+  @Test
+  void refreshTokenThrowsExceptionWhenTokenWasNotFound() {
+    // given
+    String accessToken = "access-token";
+    String refreshToken = "refresh-token";
+
+    RefreshTokenCommand refreshTokenCommand = new RefreshTokenCommand(accessToken, refreshToken);
+
+    when(tokenService.isExpired(accessToken)).thenReturn(true);
+    when(refreshTokenPort.findByToken(refreshToken)).thenReturn(null);
+
+    // when / then
+    assertThatThrownBy(() -> testSubject.refreshToken(refreshTokenCommand))
+            .isInstanceOf(RefreshTokenNotFoundException.class);
+  }
+
+  @Test
+  void refreshTokenThrowsExceptionWhenUserNotFound() {
+    // given
+    String refreshToken = "refresh-token";
+    String accessToken = "access-token";
+    RefreshToken refreshTokenEntity = new RefreshToken();
+    String username = "username";
+
+    RefreshTokenCommand refreshTokenCommand = new RefreshTokenCommand(accessToken, refreshToken);
+
+    when(tokenService.isExpired(accessToken)).thenReturn(true);
+    when(refreshTokenPort.findByToken(refreshToken)).thenReturn(refreshTokenEntity);
+    when(tokenService.getUsername(refreshToken)).thenReturn(username);
+    when(loadUserPort.loadUserByUsername(username)).thenReturn(null);
+
+    // when / then
+    assertThatThrownBy(() -> testSubject.refreshToken(refreshTokenCommand))
+            .isInstanceOf(UserNotFoundException.class);
+  }
+
+  @Test
+  void createAccessTokenCreatesTokenWhenTokenAndUserFound() {
+    // given
+    String refreshToken = "refresh-token";
+    RefreshToken refreshTokenEntity = new RefreshToken();
+    long userId = 1L;
+    String username = "username";
+    String expectedAccessToken = "expected-access-token";
+
+    User user = new User()
+            .setId(userId)
+            .setUsername(username);
+
+    when(refreshTokenPort.findByToken(refreshToken)).thenReturn(refreshTokenEntity);
+    when(tokenService.getUsername(refreshToken)).thenReturn(username);
+    when(loadUserPort.loadUserByUsername(username)).thenReturn(user);
+    when(tokenService.generateAccessToken(userId, username)).thenReturn(expectedAccessToken);
+
+    // when
+    String actualAccessToken = testSubject.createAccessToken(refreshToken);
+
+    // then
+    assertThat(actualAccessToken).isEqualTo(expectedAccessToken);
+  }
+
+  @Test
+  void createAccessTokenThrowsExceptionWhenTokenWasNotFound() {
+    // given
+    String refreshToken = "refresh-token";
+
+    when(refreshTokenPort.findByToken(refreshToken)).thenReturn(null);
+
+    // when / then
+    assertThatThrownBy(() -> testSubject.createAccessToken(refreshToken))
+            .isInstanceOf(RefreshTokenNotFoundException.class);
+  }
+
+  @Test
+  void createAccessTokenThrowsExceptionWhenUserNotFound() {
+    // given
+    String refreshToken = "refresh-token";
+    RefreshToken refreshTokenEntity = new RefreshToken();
+    String username = "username";
+
+    when(refreshTokenPort.findByToken(refreshToken)).thenReturn(refreshTokenEntity);
+    when(tokenService.getUsername(refreshToken)).thenReturn(username);
+    when(loadUserPort.loadUserByUsername(username)).thenReturn(null);
+
+    // when / then
+    assertThatThrownBy(() -> testSubject.createAccessToken(refreshToken))
+            .isInstanceOf(UserNotFoundException.class);
+  }
+
+  @Test
+  void checkUserByRefreshTokenReturnsExpectedUser() {
+    // given
+    String refreshToken = "refresh-token";
+    RefreshToken refreshTokenEntity = new RefreshToken();
+    String username = "username";
+    User expectedUser = new User();
+
+    when(refreshTokenPort.findByToken(refreshToken)).thenReturn(refreshTokenEntity);
+    when(tokenService.getUsername(refreshToken)).thenReturn(username);
+    when(loadUserPort.loadUserByUsername(username)).thenReturn(expectedUser);
+
+    // when
+    User actualUser = testSubject.checkUser(refreshToken);
+
+    // then
+    assertThat(actualUser).isEqualTo(expectedUser);
+
+    verify(tokenService).verify(refreshToken);
+  }
+
+  @Test
+  void checkUserByRefreshTokenThrowsExceptionWhenTokenWasNotFound() {
+    // given
+    String refreshToken = "refresh-token";
+
+    when(refreshTokenPort.findByToken(refreshToken)).thenReturn(null);
+
+    // when / then
+    assertThatThrownBy(() -> testSubject.checkUser(refreshToken))
+            .isInstanceOf(RefreshTokenNotFoundException.class);
+  }
+
+  @Test
+  void getUserByRefreshTokenReturnsExpectedUser() {
+    // given
+    String refreshToken = "refresh-token";
+    String username = "username";
+    User expectedUser = new User();
+
+    when(tokenService.getUsername(refreshToken)).thenReturn(username);
+    when(loadUserPort.loadUserByUsername(username)).thenReturn(expectedUser);
+
+    // when
+    User actualUser = testSubject.getUser(refreshToken);
+
+    // then
+    assertThat(actualUser).isEqualTo(expectedUser);
+  }
 }

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/RefreshTokenServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/RefreshTokenServiceTest.java
@@ -5,14 +5,18 @@ import io.reflectoring.coderadar.projectadministration.port.driven.user.RefreshT
 import io.reflectoring.coderadar.projectadministration.service.user.refresh.RefreshTokenService;
 import io.reflectoring.coderadar.projectadministration.service.user.security.TokenService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class RefreshTokenServiceTest {
 
-  private RefreshTokenPort refreshTokenPort = mock(RefreshTokenPort.class);
-  private TokenService tokenService = mock(TokenService.class);
-  private LoadUserPort loadUserPort = mock(LoadUserPort.class);
+  @Mock private RefreshTokenPort refreshTokenPort;
+
+  @Mock private TokenService tokenService;
+
+  @Mock private LoadUserPort loadUserPort;
 
   private RefreshTokenService testSubject;
 

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/RegisterUserServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/RegisterUserServiceTest.java
@@ -1,20 +1,25 @@
 package io.reflectoring.coderadar.projectadministration.user;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+
 import io.reflectoring.coderadar.projectadministration.port.driven.user.LoadUserPort;
 import io.reflectoring.coderadar.projectadministration.port.driven.user.RegisterUserPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.user.register.RegisterUserCommand;
 import io.reflectoring.coderadar.projectadministration.service.user.register.RegisterUserService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-
+@ExtendWith(MockitoExtension.class)
 class RegisterUserServiceTest {
-  private RegisterUserPort registerUserPort = mock(RegisterUserPort.class);
-  private LoadUserPort loadUserPort = mock(LoadUserPort.class);
+
+  @Mock private RegisterUserPort registerUserPort;
+
+  @Mock private LoadUserPort loadUserPort;
 
   @Test
   void returnsNewUserIdWhenRegister() {

--- a/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/RegisterUserServiceTest.java
+++ b/coderadar-core/src/test/java/io/reflectoring/coderadar/projectadministration/user/RegisterUserServiceTest.java
@@ -1,36 +1,75 @@
 package io.reflectoring.coderadar.projectadministration.user;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.reflectoring.coderadar.projectadministration.UsernameAlreadyInUseException;
+import io.reflectoring.coderadar.projectadministration.domain.User;
 import io.reflectoring.coderadar.projectadministration.port.driven.user.LoadUserPort;
 import io.reflectoring.coderadar.projectadministration.port.driven.user.RegisterUserPort;
 import io.reflectoring.coderadar.projectadministration.port.driver.user.register.RegisterUserCommand;
 import io.reflectoring.coderadar.projectadministration.service.user.register.RegisterUserService;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class RegisterUserServiceTest {
 
-  @Mock private RegisterUserPort registerUserPort;
+  @Mock private RegisterUserPort registerUserPortMock;
 
-  @Mock private LoadUserPort loadUserPort;
+  @Mock private LoadUserPort loadUserPortMock;
+
+  @Captor private ArgumentCaptor<User> userArgumentCaptor;
+
+  private RegisterUserService testSubject;
+
+  @BeforeEach
+  void setUp() {
+    this.testSubject = new RegisterUserService(registerUserPortMock, loadUserPortMock);
+  }
 
   @Test
-  void returnsNewUserIdWhenRegister() {
-    RegisterUserService testSubject = new RegisterUserService(registerUserPort, loadUserPort);
+  void registerCreatesNewUserWhenUsernameNotInUse() {
+    // given
+    String username = "username";
+    String password = "password";
+    long expectedUserId = 123L;
 
-    Mockito.when(registerUserPort.register(any())).thenReturn(1L);
-    Mockito.when(loadUserPort.existsByUsername(anyString())).thenReturn(Boolean.FALSE);
+    RegisterUserCommand registerUserCommand = new RegisterUserCommand(username, password);
 
-    RegisterUserCommand command = new RegisterUserCommand("username", "password");
-    Long userId = testSubject.register(command);
+    when(loadUserPortMock.existsByUsername(username)).thenReturn(false);
+    when(registerUserPortMock.register(any())).thenReturn(expectedUserId);
 
-    Assertions.assertEquals(1L, userId.longValue());
+    // when
+    long actualUserId = testSubject.register(registerUserCommand);
+
+    // then
+    verify(registerUserPortMock).register(userArgumentCaptor.capture());
+
+    assertThat(actualUserId).isEqualTo(expectedUserId);
+    assertThat(userArgumentCaptor.getValue().getUsername()).isEqualTo(username);
+  }
+
+  @Test
+  void registerThrowsExceptionWhenUsernameAlreadyInUse() {
+    // given
+    String username = "username";
+    String password = "password";
+
+    RegisterUserCommand registerUserCommand = new RegisterUserCommand(username, password);
+
+    when(loadUserPortMock.existsByUsername(username)).thenReturn(true);
+
+    // when / then
+    assertThatThrownBy(() -> testSubject.register(registerUserCommand))
+            .isInstanceOf(UsernameAlreadyInUseException.class);
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,4 @@ version_spring_restdocs=2.0.3.RELEASE
 tomcat.version=8.5.9
 lombok_version=1.18.6
 version_junit=5.3.2
+version_mockito_junit=3.0.0

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+# make setters return the object reference instead of void
+lombok.accessors.chain=true


### PR DESCRIPTION
Simplified tests by using the Mockito Extension for JUnit Jupiter so the
`@Mock` annotation can be used instead of initializing each mock by calling
the `Mockito#mock()` method. Added a lombok.config file to configure lombok
to return the object reference instead of void on generated setters to
simplify chaining of setter calls. Rewrote and modified most tests in coderadar
core and used AssertJ assertions.

To fix the issue of not knowing which workdir name for projects
will get generated in tests, a new inner funcational Interface called
WorkdirNameGenerator` was introduced to replace the implementation
in test runs.