### PR TITLE
fix DeleteProjectAdapter and add a test

### DIFF
--- a/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/projectadministration/project/service/DeleteProjectAdapter.java
+++ b/coderadar-graph/src/main/java/io/reflectoring/coderadar/graph/projectadministration/project/service/DeleteProjectAdapter.java
@@ -44,6 +44,7 @@ public class DeleteProjectAdapter implements DeleteProjectPort {
       List<CommitEntity> commitEntities = commitRepository.findByProjectId(id);
       commitRepository.deleteCommits(commitEntities);
       projectRepository.deleteProjectCascade(id);
+      projectRepository.deleteById(id);
       deleteWorkdir(projectEntity);
 
     } catch (IllegalArgumentException e) {

--- a/coderadar-test/src/test/java/io/reflectoring/coderadar/rest/project/DeleteProjectControllerIntegrationTest.java
+++ b/coderadar-test/src/test/java/io/reflectoring/coderadar/rest/project/DeleteProjectControllerIntegrationTest.java
@@ -25,7 +25,7 @@ class DeleteProjectControllerIntegrationTest extends ControllerTestTemplate {
   @Autowired private FilePatternRepository filePatternRepository;
 
   // This test has to be annotated with @DirtiesContext because custom Neo4j queries
-  // cause problems when run inside an DB tansaction. Therefore the transaction propagation
+  // cause problems when run inside an DB transaction. Therefore the transaction propagation
   // must be set to NOT_SUPPORTED (no transaction) to "fix" this issue.
   @Test
   @DirtiesContext
@@ -46,6 +46,20 @@ class DeleteProjectControllerIntegrationTest extends ControllerTestTemplate {
         .perform(delete("/projects/" + id))
         .andExpect(status().isOk())
         .andDo(document("projects/delete"));
+
+    Assertions.assertFalse(projectRepository.findById(id).isPresent());
+  }
+
+  @Test
+  void deleteProjectWithOnlyOneNode() throws Exception {
+    ProjectEntity testProject = new ProjectEntity();
+    testProject.setVcsUrl("https://valid.url");
+    testProject.setName("test project");
+    testProject = projectRepository.save(testProject);
+    final Long id = testProject.getId();
+
+    mvc().perform(delete("/projects/" + id))
+            .andExpect(status().isOk());
 
     Assertions.assertFalse(projectRepository.findById(id).isPresent());
   }


### PR DESCRIPTION
Now the `DeleteProjectAdapter` also deletes projects where only the node of the project is persisted. Normally, this situation should not occur, because the files and commits should be saved in the DB as well.

Note: This still is a workaround and we should implement a cypher query that deletes a whole project efficiently.